### PR TITLE
Disabling runtime provisioning test cases

### DIFF
--- a/modules/components/org.wso2.appcloud.provisioning.runtime/src/test/resources/testng.xml
+++ b/modules/components/org.wso2.appcloud.provisioning.runtime/src/test/resources/testng.xml
@@ -1,6 +1,6 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="AFRuntimeProvisioningTestSuite" verbose="2">
-    <test name="DeploymentTest" preserve-order="true" verbose="2">
+    <!--<test name="DeploymentTest" preserve-order="true" verbose="2">
         <classes>
             <class name="org.wso2.appcloud.provisioning.runtime.test.DeploymentTest"/>
         </classes>
@@ -14,5 +14,5 @@
         <classes>
             <class name="org.wso2.appcloud.provisioning.runtime.test.CustomDomainTest"/>
         </classes>
-    </test>
+    </test>-->
 </suite>


### PR DESCRIPTION
Existing runtime provisioning test cases need a kubernetes setup, so we are moving these test cases into integration test cases come up with a kubernetes setup to run these test cases as well. 